### PR TITLE
Remove device identifiers

### DIFF
--- a/CommuteStream/CommuteStream.h
+++ b/CommuteStream/CommuteStream.h
@@ -37,9 +37,7 @@
 
 - (NSString *)agencyInterest;
 
-- (NSString *)idfaSha;
-
-- (NSString *)macAddrSha;
+- (NSString *)idfa;
 
 - (NSString *)testing;
 
@@ -95,10 +93,6 @@
 - (void)setAgencyInterest:(NSString *)typeString agencyID:(NSString*)agencyIDString routeID:(NSString*)routeIDString stopID:(NSString*)stopIDString;
 
 - (void)setIdfa:(NSString *)idfa;
-
-- (void)setIdfaSha:(NSString *)idfaSha;
-
-- (void)setMacAddrSha:(NSString *)string;
 
 - (void)setTesting;
 


### PR DESCRIPTION
This removes the code to setup and send the Mac address hash and idfa hash as they are no longer needed. It also changes when and how the session id is generated to match the android sdk.